### PR TITLE
Add ability to simply restrict access to the site to only permitted u…

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,24 @@ Currently the examples cover the following;
 - [Read records](https://github.com/EnvironmentAgency/admin-prototype-kit/blob/master/app/views/pages/example3/read_record.html.erb)
 - [Form options](https://github.com/EnvironmentAgency/admin-prototype-kit/blob/master/app/views/pages/example4/forms.html.erb)
 
+## Protecting your prototypes
+
+The kit contains a simple method to restrict access to your site to only those people you want to see it. Please note the method is intended to be as simple and maintainable as possible, but should not be considered as *secure*. If you truly need to protect your work please do not rely on this method.
+
+### Enabling the key
+
+By default when the kit is running anyone who knows the url can access the site and the pages within. If however you want to restrict access you simply need to create an [environment variable](https://en.wikipedia.org/wiki/Environment_variable) within the [OS](https://en.wikipedia.org/wiki/Operating_system) you're running the kit on. For example;
+
+```bash
+export ACCESS_KEY='let-me-in'
+```
+
+It must be named `ACCESS_KEY` and contain a value, however the value can be whatever you want. From then on whenever someone requests a page without supplying the access key they will instead see the [public/private.html.erb](https://github.com/EnvironmentAgency/admin-prototype-kit/tree/master/public) page.
+
+### Providing the key
+
+Having set the key you should then give it to only those users permitted to access the site. In order to supply it they should use a URL like this **mysite.co.uk?access_key=let-me-in** when first accessing the site. As long as it matches the kit will then create a permanent cookie with the key value in, so any subsequent requests and visits to the site will no longer need the argument specified.
+
 ## Layout
 
 As well as static pages, you can use content_for hooks to inject content into in the GDS template.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,34 @@
 class ApplicationController < ActionController::Base
-  
+
+  # Adding this before filter here means it is called before every action in
+  # every controller in the kit.
+  before_filter :check_access_key
+
+  # This is used to protect access to your website when deployed to a public
+  # environment like Heroku. If this environment variable has not been
+  # set then any one can access the site. If it has then the key will need to
+  # be provided either as a url argument or in your cookies. What the key is
+  # is up to you!
+  # Idea taken from http://stackoverflow.com/a/4840094
+  def check_access_key
+    # First check if the access_key environment variable has been set. If it
+    # hasn't the method will exit and the kit will continue as is.
+    key = ENV['ACCESS_KEY']
+    return unless key
+
+    # The variable has been set so now we check for it either in the request
+    # url as an argument e.g. http://www.yourdomain.com?access_key=random_string
+    # or in a cookie. If no match we return the private.html page.
+    if request[:access_key] != key && cookies[:access_key] != key
+      render file: '/public/private.html'
+    elsif request[:access_key] == key
+      # The first time a new user hits the site they will need to provide the
+      # key as an argument in the URL. Having done that this then creates a
+      # permanent cookie so they no longer have to add the argument to the url.
+      cookies.permanent[:access_key] = key
+    end
+
+    # If we get here its because the user has supplied the correct access key.
+    # This means the method will simply exit and the kit will continue as is.
+  end
 end

--- a/public/private.html.erb
+++ b/public/private.html.erb
@@ -1,0 +1,8 @@
+<h1>Private site</h1>
+
+<p>The site you've tried to access is used as part of developing prototypes
+  for back end systems which support digital services on
+  <a href='https://www.gov.uk'>GOV.UK</a>.</p>
+
+<p>It's nothing super special or secret, but we're either not quite ready
+  or not able to show these screens publicly.</p>


### PR DESCRIPTION
…sers

The idea is that you are probably using a service like heroku to host your prototypes to enable users to access it in order to give feedback. However either because you don't believe the prototype is ready, or because it exposes sensitive functionality or content you want to be able to restrict access to it. We have intentionally created a simple way to do this, that just requires creating a single shared key. Anyone you give the key to will then be able to access the site, everyone else will get the public/private.html.erb page which you can edit to your liking. More details will be available in the GitHub repo.