### PR TITLE
Replace call to env variable for production secret_key_base to fixed …

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -20,4 +20,4 @@ test:
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  secret_key_base: b884fa603b78d7000e654e0fb01df0e6f4f9954284c7bffac47b31d855d6c03d014ae2429acbe3ba6a11def8ec9a38c3e619993c869a76b18bed45d777e5724a


### PR DESCRIPTION
…value

The kit is not intended to be used as a production system, with the priority being to make it as simply to use as possible. Therefore update the prod secret_key_base to be a set value so that should a user attempt to run it in production mode they won't get an error because they didn't know to also create the relevant environment variable.