### PR TITLE
Correct rails version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In a word, **don't**. This kit has been designed for prototyping, not production
 
 ## Versions
 
-The project is currently using Ruby version 2.2.2 and Rails 4.2.0.
+The project is currently using Ruby version 2.2.2 and Rails 4.2.
 
 ## Obtain the source
 


### PR DESCRIPTION
Having updated the version of Rails in a previous PR (#46) we forgot to update the version of rails referenced in the README.

This change corrects that, as well as choosing to not be so specific. We now feel its not necessary to explicitly state the reference in the README, and should lead to less errors keeping the documentation up to date.