### PR TITLE
Add proto_controller show test

### DIFF
--- a/spec/controllers/proto_pages_controller_spec.rb
+++ b/spec/controllers/proto_pages_controller_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe ProtoPagesController, '#show' do
+  HighVoltage.page_ids.each do |page|
+    context "on GET to /pages/#{page}" do
+      before do
+        get :show, id: page
+      end
+
+      it { expect(response).to have_http_status(:ok) }
+    end
+  end
+end


### PR DESCRIPTION
Whilst the project is not being actively worked on we use Deppbot to ensure our dependencies are up to date.

However recently when returning to the project we found the static pages were no longer loading. Therefore this change adds a test to check that all static pages return 'ok' when called so our CI server can hopefully flag an issue, rather than waiting to find it for ourselves.